### PR TITLE
[feature] Make it possible to set custom error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
       with:
         title-regex: '^\[PROJECT-\d*\](\ )'
         title-regex-flags: 'g' # optional
+        error-message: 'Add Jira ID to your title' # optional
 ```
 
 In this example, for every pull request the title is expected to match `^\[PROJECT-\d*\]\ ` regex with a global flag `g`. For instance, `[PROJECT-123] lorem ipsum` or `[PROJECT-2345] dolor sit amet` are valid titles for this example. You can customize the title regex for your needs. The regex flags configuration is optional.

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,13 @@ async function run() {
     const
       titleRegex = core.getInput('title-regex', {required: true}),
       titleRegexFlags = core.getInput('title-regex-flags') || 'g',
+      errorMessage = core.getInput('error-message') || `Please fix your PR title to match "${titleRegex}" with "${titleRegexFlags}"`,
       title = github.context!.payload!.pull_request!.title;
 
     core.info(`Checking "${titleRegex}" with "${titleRegexFlags}" flags against the PR title: "${title}"`);
 
     if (!title.match(new RegExp(titleRegex, titleRegexFlags))) {
-      core.setFailed(`Please fix your PR title to match "${titleRegex}" with "${titleRegexFlags}" flags, and re-trigger the check by pushing a new commit. See https://github.com/seferov/pr-lint-action#known-issues`);
+      core.setFailed(errorMessage);
 
       const autoCloseMessage = core.getInput('auto-close-message'),
         githubToken = core.getInput('github-token');


### PR DESCRIPTION
Seems reasonable to have an option to set a custom error message in case the check fails.

I also removed _and re-trigger the check by pushing a new commit_ phrase as the check is triggered by simply changing the title, no need to push anything in this case.