### PR TITLE
Add non-requrired fields as inputs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,6 +8,8 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: seferov/pr-lint-action@master
+    - uses: MNThomson/pr-lint-action@max/add-options
       with:
-        title-regex: '^(\[[a-z ]*\]|Bump) '
+        title-regex: '^\[\w*\](\ )'
+        title-regex-flags: 'g'
+        error-message: 'Add [] to beginning of PR title'

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,8 +8,8 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: MNThomson/pr-lint-action@max/add-options
+    - uses: seferov/pr-lint-action@${{ github.ref_name }}
       with:
-        title-regex: '^\[\w*\](\ )'
+        title-regex: '^(\[[a-z ]*\]|Bump) '
         title-regex-flags: 'g'
-        error-message: 'Add [] to beginning of PR title'
+        error-message: 'Example error message'

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,7 +8,7 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: seferov/pr-lint-action@${{ github.ref_name }}
+    - uses: seferov/pr-lint-action@master
       with:
         title-regex: '^(\[[a-z ]*\]|Bump) '
         title-regex-flags: 'g'

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,18 @@ inputs:
     description: 'Title regex to match'
     required: true
     default: '^\[PROJECT-\d*\]\ '
+  title-regex-flags:
+    description: 'Regex flags'
+    required: false
+  error-message:
+    description: 'Custom error message to display'
+    required: false
+  auto-close-message:
+    description: 'Close the PR if the title does not match the pattern provided'
+    required: false
+  github-token:
+    description: 'GitHub access token'
+    required: false
 branding:
   icon: 'edit-3'
   color: 'blue'


### PR DESCRIPTION
## Description
Currently, the provided example does not work. This is because in the [action.yml](https://github.com/seferov/pr-lint-action/blob/master/action.yml) file, the additional options aren't listed. Running the action with additional args results in an error:
```yml
- uses:seferov/pr-lint-action@master
  with:
    title-regex: '^\[\w*\](\ )'
    title-regex-flags: 'g'
    error-message: 'Add [] to beginning of PR title'
```
```
Unexpected input(s) 'title-regex-flags', 'error-message', valid inputs are ['entryPoint', 'args', 'title-regex']
```
Closes #231

## Example
Take a look at [this example PR](https://github.com/MNThomson/pr-lint-action/runs/7267692995?check_suite_focus=true) (running CI from my fork) to show the output (running CI on this PR should fail since the CI is running against `master`).

Additional request to create a new release after the merge so that I can pin my actions as opposed to pinning to `master` (which is usually not a good idea)